### PR TITLE
Change build dir to build/platform/architecture

### DIFF
--- a/src/raft/core/project.ts
+++ b/src/raft/core/project.ts
@@ -149,7 +149,7 @@ export class Project {
      * @return {Path}                    The directory the project should be built in.
      */
     dirForBuild(build : Build) {
-        return this.root.append(Project.BUILD_DIR);
+        return this.root.append(Project.BUILD_DIR, build.platform.name, build.architecture.name);
     }
 
     /**


### PR DESCRIPTION
Raft can be used to cross-compile. If a tool is consuming artifacts
built by Raft, it needs to know where each build is located. One example
is using gradle to pull all of the libraries into the APK. Nesting the
build directories allows tools to know the location by convention.